### PR TITLE
Add scripts for tagging existing radanalyticsio images

### DIFF
--- a/push_tag.sh
+++ b/push_tag.sh
@@ -16,7 +16,7 @@ fi
 push_tag $1
 if [ "$?" -eq 0 ]; then
     echo
-    echo "Tagged images pushed successfull"
+    echo "Tagged images pushed successfully"
 else
     echo
     echo "Failed to push tagged images"

--- a/push_tag.sh
+++ b/push_tag.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+function push_tag() {
+    docker push docker.io/radanalyticsio/radanalytics-pyspark:$1 || return 1
+    docker push docker.io/radanalyticsio/radanalytics-java-spark:$1 || return 1
+    docker push docker.io/radanalyticsio/radanalytics-scala-spark:$1 || return 1
+    docker push docker.io/radanalyticsio/oshinko-rest:$1 || return 1
+    docker push docker.io/radanalyticsio/oshinko-webui:$1 || return 1
+}
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: push_tag.sh TAG"
+    exit 1
+fi
+
+push_tag $1
+if [ "$?" -eq 0 ]; then
+    echo
+    echo "Tagged images pushed successfull"
+else
+    echo
+    echo "Failed to push tagged images"
+    exit -1
+fi

--- a/set_tag.sh
+++ b/set_tag.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+if [ "$#" -ne 2 ]; then
+    echo "Usage: set_tag.sh VERSION TAG"
+    exit -1
+fi
+
+#set -e
+function pull_and_tag() {
+    docker pull docker.io/radanalyticsio/radanalytics-pyspark:$1 || return 1
+    docker pull docker.io/radanalyticsio/radanalytics-java-spark:$1 || return 1
+    docker pull docker.io/radanalyticsio/radanalytics-scala-spark:$1 || return 1
+    docker pull docker.io/radanalyticsio/oshinko-rest:$1 || return 1
+    docker pull docker.io/radanalyticsio/oshinko-webui:$1 || return 1
+
+    docker tag docker.io/radanalyticsio/radanalytics-pyspark:$1 docker.io/radanalyticsio/radanalytics-pyspark:$2 || return 1
+    docker tag docker.io/radanalyticsio/radanalytics-java-spark:$1 docker.io/radanalyticsio/radanalytics-java-spark:$2 || return 1
+    docker tag docker.io/radanalyticsio/radanalytics-scala-spark:$1 docker.io/radanalyticsio/radanalytics-scala-spark:$2 || return 1
+    docker tag docker.io/radanalyticsio/oshinko-rest:$1 docker.io/radanalyticsio/oshinko-rest:$2 || return 1
+    docker tag docker.io/radanalyticsio/oshinko-webui:$1 docker.io/radanalyticsio/oshinko-webui:$2 || return 1
+}
+
+pull_and_tag $1 $2
+if [ "$?" -eq 0 ]; then
+    echo
+    echo "Images pulled and tagged successfully"
+else
+    echo
+    echo "Failed to pull and tag all images"
+    exit -1
+fi


### PR DESCRIPTION
The set_tag.sh and push_tag.sh scripts can be used to tag
existing images on docker.io. For example, to mark the
latest set of released images with a "stable" tag.