### PR TITLE
Added oshinko-version fix when starting release job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -231,7 +231,7 @@ withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'radly-
                     tmpdir = tmpdir.trim()
 
                     try {
-                        build job: cliJob, propagate: true, wait: true
+                        build job: cliJob, parameters:  [string(name: 'VERSION', value: "v${OSHINKO_VERSION}")], propagate: true, wait: true
                         copyArtifacts(projectName: cliJob, target: tmpdir)
                         String artifactsDir = "${tmpdir}/src/github.com/${GH_REPO_OWNER}/${GH_REPO}/bin" as String
 


### PR DESCRIPTION
Will start the oshinko cli binary release job with the specified oshinko version as a parameter. 